### PR TITLE
centos compile openssl libs not found 

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -34,7 +34,7 @@ endif
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei -lcrypto -lssl
 LDFLAGS += -shared
 
 # Verbosity.


### PR DESCRIPTION
cause error:
Failed to load NIF library: '/xxxx/crypto_ext/_build/dev/lib/crypto_ext/priv/crypto_ext.so: undefined symbol: OpenSSLDie

```
>pkg-config --libs openssl
-lssl -lcrypto
```
